### PR TITLE
chore: [sc-71009] Replace urllib3-future with urllib3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "DateTime",
         "setuptools<=81.0.0",
         "six",
-        "urllib3-future",
+        "urllib3",
         "jwcrypto",
         "cryptography",
         "pgpy"


### PR DESCRIPTION
## Summary
- Replaces `urllib3-future` with `urllib3` in `setup.py`
- Upstream v0.0.75 switched to `urllib3-future`, but it overwrites the `urllib3` namespace and causes `IncompleteRead` errors in peach's test suite (Flask test client + requests_mock)
- The cybersource code only uses standard urllib3 APIs (`PoolManager`, `ProxyManager`, `Timeout`, `make_headers`, `BaseHTTPResponse`, exceptions) — nothing urllib3-future-specific

## Test plan
- [ ] peach CI tests pass with the new rev pointing to this commit

[sc-71009](https://app.shortcut.com/peachfinance/story/71009)

🤖 Generated with [Claude Code](https://claude.com/claude-code)