### PR TITLE
fix: Replace BaseHTTPResponse with urllib3.HTTPResponse for 1.x compat

### DIFF
--- a/CyberSource/utilities/pgpBatchUpload/mutual_auth_upload.py
+++ b/CyberSource/utilities/pgpBatchUpload/mutual_auth_upload.py
@@ -3,7 +3,6 @@ import uuid
 
 import certifi
 import urllib3
-from urllib3 import BaseHTTPResponse
 
 import CyberSource.logging.log_factory as LogFactory
 from authenticationsdk.util.GlobalLabelParameters import GlobalLabelParameters
@@ -137,7 +136,7 @@ class MutualAuthUpload:
         ca_cert_path: str,
         cert_password: str = None,
         verify_ssl: bool = True,
-    ) -> BaseHTTPResponse:
+    ) -> urllib3.HTTPResponse:
         """
         Send HTTP request with the file and certificates.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 certifi
 pycryptodome
-PyJWT
 DateTime
-setuptools
+setuptools<=81.0.0
 six
-urllib3-future
+urllib3
 jwcrypto
 cryptography
+pgpy


### PR DESCRIPTION
## Summary
- Replace `from urllib3 import BaseHTTPResponse` with `urllib3.HTTPResponse` in `mutual_auth_upload.py` — `BaseHTTPResponse` only exists in urllib3 2.x, but peach pins 1.26.x
- Sync `requirements.txt` with `setup.py` (drop `PyJWT`, `urllib3-future`; add `pgpy`, `urllib3`; pin `setuptools<=81.0.0`)

## Context
This is a follow-up to PR #3 which replaced `urllib3-future` with `urllib3` in `setup.py` but missed the import in `mutual_auth_upload.py`, causing an `ImportError` in peach CI:
```
from urllib3 import BaseHTTPResponse
ImportError: cannot import name 'BaseHTTPResponse' from 'urllib3'
```

## Test plan
- [ ] peach CI unit tests pass after pinning to this rev

🤖 Generated with [Claude Code](https://claude.com/claude-code)