### PR TITLE
fix: Indent config log line into enable_log block

### DIFF
--- a/authenticationsdk/core/MerchantConfiguration.py
+++ b/authenticationsdk/core/MerchantConfiguration.py
@@ -613,7 +613,7 @@ class MerchantConfiguration:
             for keys, values in list(details_copy.items()):
                 details_copy[keys] = str(values)
 
-        self.logger.info("Mconfig >      " + str(ast.literal_eval(json.dumps(details_copy))))
+            self.logger.info("Mconfig >      " + str(ast.literal_eval(json.dumps(details_copy))))
 
         import numbers
         if not isinstance(self.max_num_idle_connections, numbers.Number):


### PR DESCRIPTION
## Summary
- Fixes `ast.literal_eval` crash when `enable_log` is `False`
- In v0.0.75 this log line was moved outside the `if enable_log` block, causing it to always run with un-stringified values (JSON `false` != Python `False`)

## Context
Follow-up to PR #4. The `_get_api()` constructor was silently failing with `malformed node or string on line 1` because `MerchantConfiguration.__init__` crashed on this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)