### PR TITLE
fix: urllib3 1.x compatibility fixes for v0.0.75

### DIFF
--- a/CyberSource/rest.py
+++ b/CyberSource/rest.py
@@ -78,8 +78,6 @@ class RESTClientObject(object):
                     key_password=hash_candidates_dict['key_password'],
                     proxy_url=hash_candidates_dict['proxy'],
                     proxy_headers=hash_candidates_dict['proxy_auth_headers'],
-                    keepalive_delay=hash_candidates_dict['keepalive_delay'],
-                    keepalive_idle_window=hash_candidates_dict['keepalive_idle_window']
                 )
             else:
                 my_pool_manager = urllib3.PoolManager(
@@ -90,8 +88,6 @@ class RESTClientObject(object):
                     cert_file=hash_candidates_dict['cert_file'],
                     key_file=hash_candidates_dict['key_file'],
                     key_password=hash_candidates_dict['key_password'],
-                    keepalive_delay=hash_candidates_dict['keepalive_delay'],
-                    keepalive_idle_window=hash_candidates_dict['keepalive_idle_window']
                 )
 
             cls._urllib3_poolmanagers[hashed_key] = my_pool_manager

--- a/CyberSource/utilities/tracking/sdk_tracker.py
+++ b/CyberSource/utilities/tracking/sdk_tracker.py
@@ -47,9 +47,9 @@ class SdkTracker:
             if merchantConfig_developerId is not None and merchantConfig_developerId.strip() != "":
                 developer_id_value = merchantConfig_developerId.strip()
 
-            if 'client_reference_information' not in tester:
+            if 'client_reference_information' not in tester or tester['client_reference_information'] is None:
                 tester['client_reference_information'] = {}
-            if 'partner' not in tester['client_reference_information']:
+            if 'partner' not in tester['client_reference_information'] or tester['client_reference_information']['partner'] is None:
                 tester['client_reference_information']['partner'] = {}
             if 'developer_id' not in tester['client_reference_information']['partner'] or not tester['client_reference_information']['partner']['developer_id']:
                 tester['client_reference_information']['partner']['developer_id'] = developer_id_value


### PR DESCRIPTION
## Summary
Three fixes for urllib3 1.x compatibility after replacing urllib3-future with urllib3:

- **sdk_tracker.py**: Handle `None` values in `insert_developer_id_tracker` — when request JSON has `"partner": null`, the `in` check passes but the value is None, causing TypeError
- **MerchantConfiguration.py**: Indent `ast.literal_eval` log line back into the `enable_log` block — in v0.0.75 it was moved outside, causing crash when `enable_log=False` (JSON `false` != Python `False`)
- **rest.py**: Remove `keepalive_delay` and `keepalive_idle_window` params from PoolManager/ProxyManager — these are urllib3-future features not in standard urllib3 1.x

## Test plan
- [x] All 7 previously failing `test_cards_cybersource.py` tests pass locally with these fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)